### PR TITLE
Update resourceService.go add default namescape in CreateResource

### DIFF
--- a/ginTools/pkg/services/resourceService.go
+++ b/ginTools/pkg/services/resourceService.go
@@ -60,7 +60,11 @@ func (r *ResourceService) CreateResource(resourceOrKindArg string, yaml string) 
 	if err != nil {
 		return err
 	}
-
+	
+	if obj.GetNamespace() == "" {
+		obj.SetNamespace("default")
+	}
+	
 	_, err = ri.Create(context.Background(), obj, metav1.CreateOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
we should double check the request url with /namespaces/{namescapeName}/pods,otherwise we will get the err as following in some k8s server version.
k8s server version `v1.30.5`
```
curl --location 'http://127.0.0.1:8080/pods' \
--header 'Content-Type: application/json' \
--data '{"yaml": "{\"kind\":\"Pod\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"foo-app\",\"labels\":{\"app\":\"foo\"}},\"spec\":{\"containers\":[{\"name\":\"foo-app\",\"image\":\"higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/http-echo:0.2.4-alpine\"}],\"args\":[\"--text=foo\"]}}"}'

{"error":"创建失败：the server does not allow this method on the requested resource"}
```